### PR TITLE
Fix Ordinal __add__ operand mutation

### DIFF
--- a/transfinite/ordinals.py
+++ b/transfinite/ordinals.py
@@ -239,7 +239,7 @@ class Ordinal(BasicOrdinal):
                 raise ValueError("can only add positive integers to ordinal")
             terms = self.terms[:]
             if self.is_successor:
-                terms[-1][0] += other
+                terms[-1] = [terms[-1][0] + other]
             else:
                 terms.append([other])
             return Ordinal(terms)


### PR DESCRIPTION
This commit fixes the following issue:

>>> from transfinite import w
>>> x = w+1
>>> x
\omega + 1
>>> x+1
\omega + 2
>>> x
\omega + 2

by avoiding to mutate the addition operand:

>>> from transfinite import w
>>> x = w+1
>>> x
\omega + 1
>>> x+1
\omega + 2
>>> x
\omega + 1
